### PR TITLE
Remove legacy bit in Privacy Policy

### DIFF
--- a/web/src/pages/PrivacyPolicy.tsx
+++ b/web/src/pages/PrivacyPolicy.tsx
@@ -35,23 +35,6 @@ service provider, referring/exit pages, and date/time stamps.
 
 ---
 
-### Data Retention
-When you choose to upload your chat.db and optionally choose to upload your contacts file to our site, we query the 
-chat.db file and parse the .vcf to create your unique dashboard page. We then encrypt the words of your text messages 
-end-to-end using your provided encryption key, which we do not store. We do, however, retain other data required to 
-render your dashboard. The data required to render your dashboard is extracted from the files you uploaded and includes 
-the frequency of the words you sent, the length of each text, the dates you texted, the time you texted, the contact 
-information of the people you texted (if uploaded). We store this data because we cannot render your dashboard without 
-it. But again, we want to emphasize that the words that you texted and recieved are encrypted (provided you gave a key), 
-and therefore unable to be read. Using regular expressions software, we redact potientially private information such as 
-Social Security numbers and Credit Card information. If you choose to upload your contacts file, you have the option to 
-choose which conversations you upload, in which case the unselected conversations are never stored and deleted with the 
-file. We do not store images, as images are not included in the uploaded chat.db file. Ultimately, all this data is stored 
-in a database and, even though it is encrypted, is subject to hack. By uploading your chat.db or your contacts file you 
-recognize your data may be compromised. You will not and do not hold Left on Read accountable for any data compromised.
-
----
-
 ### Sharing Your Information
 We use Google Analytics to help us understand how our users use the Site: you can read more about how Google uses your 
 Personal Information here. You can also opt-out of Google Analytics here.


### PR DESCRIPTION
This part of privacy policy no longer applies and is inaccurate. (It is leftover from the web application from 2019.)