### PR TITLE
[app] Clarify that Group Chat Filtering Message

### DIFF
--- a/app/src/chatBro/constants/filters.ts
+++ b/app/src/chatBro/constants/filters.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_LIMIT = 15;
 
 export enum GroupChatFilters {
-  BOTH = 'Both Individual and Group Chats (will make received higher)',
+  BOTH = 'Both Individual and Group Chats (makes received higher & keeps sent the same)',
   ONLY_INDIVIDUAL = 'Only Individual Conversations',
 }
 

--- a/app/src/chatBro/constants/filters.ts
+++ b/app/src/chatBro/constants/filters.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_LIMIT = 15;
 
 export enum GroupChatFilters {
-  BOTH = 'Both Individual and Group Chats',
+  BOTH = 'Both Individual and Group Chats (will make received higher)',
   ONLY_INDIVIDUAL = 'Only Individual Conversations',
 }
 


### PR DESCRIPTION

- Clarify that Group Chats should make received higher because group chat filter stacks individual texts + group chat texts, so it includes DOUBLE the received, but only one source of sent.