### PR TITLE
[app] Change getDBWithRecordCounts to never return undefined

### DIFF
--- a/app/src/addressBro/util/index.ts
+++ b/app/src/addressBro/util/index.ts
@@ -27,11 +27,12 @@ async function readAddressBookBackups(): Promise<sqlite3.Database | undefined> {
         return getDBWithRecordCounts(path, COUNT_CONTACTS_QUERY);
       })
     );
-    if (dbRecordCountResults && dbRecordCountResults[0]) {
+    if (dbRecordCountResults.length > 0) {
       // get db with biggest record counts
       const getMaxDBRC = (dbrcList: DBWithRecordCount[]) =>
         dbrcList.reduce((a, b) => (a.recordCount > b.recordCount ? a : b));
-      const maxDB = getMaxDBRC(dbRecordCountResults as DBWithRecordCount[]);
+
+      const maxDB = getMaxDBRC(dbRecordCountResults);
       return maxDB.db;
     }
     log.warn(`WARN: ${addressBookBackUpFolderPath} dbs are all empty.`);

--- a/app/src/db/index.ts
+++ b/app/src/db/index.ts
@@ -24,19 +24,19 @@ export async function getRecordCounts(
     log.info(`INFO: ${checkResult[0].count} records found`);
     return checkResult[0].count;
   }
-  log.info(`INFO: ${db} - no records found`);
+  log.info(`INFO: no records found`);
   return 0;
 }
 
 export interface DBWithRecordCount {
-  db: sqlite3.Database;
+  db: sqlite3.Database | null;
   recordCount: number;
 }
 
 export async function getDBWithRecordCounts(
   dbPath: string,
   checkQuery: string
-): Promise<DBWithRecordCount | undefined> {
+) {
   log.info(`INFO: attempting to initialize ${dbPath}`);
   if (fs.existsSync(dbPath)) {
     const db = initializeDB(dbPath);
@@ -46,5 +46,5 @@ export async function getDBWithRecordCounts(
     }
     return { db, recordCount };
   }
-  return undefined;
+  return { db: null, recordCount: 0 };
 }


### PR DESCRIPTION
Previously, if the db path did not exist, then undefined was returned, breaking the logic to find the biggest address book. There's some funkyness going on with the types.