### PR TITLE
Fix Core Table Joins: Group Chat Problem and Missing Old Sent Messages Found only in Joins

### DIFF
--- a/app/src/analysis/tables/CoreTable.ts
+++ b/app/src/analysis/tables/CoreTable.ts
@@ -47,17 +47,32 @@ export class CoreMainTable extends Table {
       -- TODO(Danilowicz): every query should just use coalesced_contact_name
       -- instead of coalescing themselves
       coalesce(contact_name, id) as coalesced_contact_name
-    FROM
-    message m
-    -- The left join is important here, because handle_id 0 is used when you send group messages
+    -- Some texts sent to individuals 
+    -- dont show up unless
+    -- you take the ROWID of the message
+    -- get the chat_id
+    -- get the handle_id,
+    -- then join to the handle table.
+    -- It's not enough to simply join on the handle table.
+    -- Also, when you send a group message
+    -- it is assigned a handle_id of 0
+    -- and handle_id of 0 is not present in the join tables.
+
+    FROM message m
+    LEFT JOIN chat_message_join cmj
+    ON
+    m.ROWID = cmj.message_id
+    LEFT JOIN chat_handle_join chj
+    USING(chat_id)
     LEFT JOIN handle h
-      ON h.rowid = m.handle_id
+    ON
+    -- What you join is super important here
+    -- if you do m.handle_id then you will have null contact_names
+    h.ROWID = chj.handle_id 
+
 
     JOIN DATE_TIME_TABLE
       ON m.guid = datetimetable_guid 
-
-    LEFT JOIN chat_message_join c
-      ON c.message_id = m.ROWID
     WHERE ${fluffFilter()}
     `;
 


### PR DESCRIPTION
Two problems at play here:

1. It appears for some messages — particularly old messages — the handle_id is 0 (or non-present, I'm not totally sure?) in the messages table. (The handle_id is also 0 when you send messages in group chats.)

To solve this, we need to join messages to chats and then chats to handles. It appears that the chat_handle join table has MORE handle_ids populated then the messages table. 

2. However, if we use the join tables, then group chats messages are duplicated, which makes sense because there are multiple handles in a given chat. Also, then we need to attribute the handle_id in the message table as the contact, not the handle_id in the join tables.

So, to solve both of these, we do a CASE WHEN in the join.

When it's a group chat, we use the message table handle_id.
When it's not a group chat, we use the join tables.
Finally, we GROUP BY the message's guid to remove duplicates (this part could maybe use some improvement.)

