### PR TITLE
Move Engagement Charts to Productivity Tab

### DIFF
--- a/app/src/components/Dashboard/ChartTabs.tsx
+++ b/app/src/components/Dashboard/ChartTabs.tsx
@@ -149,9 +149,6 @@ export function ChartTabs({ filters }: { filters: SharedQueryFilters }) {
           <Tab style={{ marginRight: 32 }}>
             <span style={{ marginRight: 10 }}>❤️</span>Sentiment
           </Tab>
-          <Tab style={{ marginRight: 32 }}>
-            <span style={{ marginRight: 10 }}>⚡ </span>Engagement
-          </Tab>
         </TabList>
         <TabPanels style={{ padding: '70px 36px 36px 36px' }}>
           <TabPanel>
@@ -298,26 +295,32 @@ export function ChartTabs({ filters }: { filters: SharedQueryFilters }) {
               />
             </Stack>
           </TabPanel>
-          <TabPanel>
-            <Stack direction="column" spacing={40}>
-              <RespondReminders />
-              <MessageScheduler />
-              <EngagementScoreChart
-                title={titleFormatter({
-                  titleName: 'Engagement Score ™',
-                  filters,
-                })}
-                description={descriptionFormatter({
-                  description: `Measures how "good" of a texter you are`,
-                  filters,
-                })}
-                icon={FiRadio}
-                filters={filters}
-              />
-            </Stack>
-          </TabPanel>
         </TabPanels>
       </Tabs>
     </div>
+  );
+}
+
+export function EngagementCharts() {
+  // TODO(Danilowicz): This needs to be refactored and be props
+  // { filters }: { filters: SharedQueryFilters }
+  const filters = {};
+  return (
+    <Stack direction="column" spacing={40}>
+      <RespondReminders />
+      <MessageScheduler />
+      <EngagementScoreChart
+        title={titleFormatter({
+          titleName: 'Engagement Score ™',
+          filters,
+        })}
+        description={descriptionFormatter({
+          description: `Measures how "good" of a texter you are`,
+          filters,
+        })}
+        icon={FiRadio}
+        filters={filters}
+      />
+    </Stack>
   );
 }

--- a/app/src/components/Dashboard/Dashboard.tsx
+++ b/app/src/components/Dashboard/Dashboard.tsx
@@ -1,9 +1,11 @@
+import { Box } from '@chakra-ui/react';
 import Store from 'electron-store';
 import { useState } from 'react';
 
 import { SettingsPage } from '../Pages/SettingsPage';
 import { GoldContext } from '../Premium/GoldContext';
 import { AnalyticsPage } from './AnalyticsPage';
+import { EngagementCharts } from './ChartTabs';
 import { SIDEBAR_WIDTH, SideNavbar, TPages } from './SideNavbar';
 
 const store = new Store();
@@ -38,6 +40,12 @@ export function Dashboard({ onRefresh }: { onRefresh: () => void }) {
         <div style={{ flex: '1 1 0', minWidth: 0 }}>
           {activePage === 'Analytics' && (
             <AnalyticsPage onRefresh={onRefresh} />
+          )}
+          {activePage === 'Productivity' && (
+            // TODO(Danilowicz): Should make a shared container
+            <Box style={{ padding: '70px 36px 36px 36px' }}>
+              <EngagementCharts />
+            </Box>
           )}
           {activePage === 'Settings' && <SettingsPage />}
         </div>

--- a/app/src/components/Dashboard/SideNavbar.tsx
+++ b/app/src/components/Dashboard/SideNavbar.tsx
@@ -10,6 +10,7 @@ import {
 import { ipcRenderer } from 'electron';
 import { IconType } from 'react-icons';
 import { BsLightningCharge } from 'react-icons/bs';
+import { FiClipboard } from 'react-icons/fi';
 
 import LogoWithText from '../../../assets/LogoWithText.svg';
 import { APP_VERSION } from '../../constants/versions';
@@ -17,10 +18,7 @@ import { useGoldContext } from '../Premium/GoldContext';
 import { PremiumModal } from '../Premium/PremiumModal';
 import { EmailModal } from '../Support/EmailModal';
 
-const Pages = ['Analytics', 'Settings'] as const;
-
-// TODO(ALEX): PRODUCTIVITY
-// const Pages = ['Productivity', 'Analytics', 'Settings'] as const;
+const Pages = ['Analytics', 'Productivity', 'Settings'] as const;
 
 export const SIDEBAR_WIDTH = 200;
 
@@ -99,13 +97,10 @@ export function SideNavbar({
         <div style={{ marginTop: '25%' }}>
           <Stack direction="column" alignItems="flex-start">
             {Pages.filter((page) => page !== 'Settings').map((page) => {
-              const icon = BsLightningCharge;
-
-              // if (page === 'Analytics') {
-              //   icon = FiBarChart;
-              // } else if (page === 'Reports') {
-              //   icon = FiClipboard;
-              // }
+              let icon = BsLightningCharge;
+              if (page === 'Productivity') {
+                icon = FiClipboard;
+              }
 
               return (
                 <SidebarMainLink


### PR DESCRIPTION
Couple of TODOs here for me (@alexdanilowicz). For example, there's a regression where you can no longer filter the engagement charts, but I think it's fine to merge honestly. Will refactor shortly, just wanted to get both PRs in a mergeable state.

<img width="1201" alt="Screen Shot 2022-09-22 at 5 24 55 PM" src="https://user-images.githubusercontent.com/29822597/191873103-1fc795bc-c9a1-442e-a372-e17589e4241d.png">
