### PR TITLE
fix: window destroyed exceptions

### DIFF
--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -86,7 +86,10 @@ class AppUpdater {
         event.sender.send('update-available');
       });
 
-      // event.sender.send('update-available');
+      // When the window is closed (ie. destroyed), don't send any events
+      if (!event.sender.isDestroyed()) {
+        event.sender.send('update-available');
+      }
     });
   }
 }


### PR DESCRIPTION
fixes the following error
```
Uncaught Exception:
TypeError: Object has been destroyed at EventEmitter.send (node:electron/is2c/ browser_init:161:2484)
at p. ‹anonymous> (/Applications/Left on Read.app/Contents/Resources/app.asar/ dist/main/webpack:/src/main/ main.ts:86:22)
at p.emit (node:events:402:35)
at p.dispatchUpdateDownloaded (/ Applications/Left on Read.app/Contents/ Resources/app.asar/dist/main/webpack:/ node_modules/electron-updater/out/ AppUpdater.js:390:14)
at Server.<anonymous> (/Applications/ Left on Read.app/Contents/Resources/
```

which is caused by referencing the BrowserWindow sender's webcontents. this change ignores `listen-for-updates` events from rendered that have been closed.