### PR TITLE
Set lastUpdatedVersion in initialize directly

### DIFF
--- a/app/src/components/Initializer.tsx
+++ b/app/src/components/Initializer.tsx
@@ -11,7 +11,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { FiLifeBuoy, FiRepeat, FiSkipBack } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
-import { APP_VERSION } from '../constants/versions';
 import { BarChartLoading } from './Loaders/BarChartLoading';
 import { InitializingTextSlider } from './Loaders/InitializingTextSlider';
 import { EmailModal } from './Support/EmailModal';
@@ -62,7 +61,6 @@ export function Initializer({
     try {
       navigate('/start');
       await ipcRenderer.invoke('initialize-tables', isRefresh);
-      await ipcRenderer.invoke('set-last-updated-version', APP_VERSION);
       setProgressNumber(99);
       navigate('/dashboard');
     } catch (e: unknown) {

--- a/app/src/main/ipcListeners.ts
+++ b/app/src/main/ipcListeners.ts
@@ -85,6 +85,7 @@ function getDb() {
 
 export function attachIpcListeners() {
   ipcMain.handle('initialize-tables', async (event, isRefresh) => {
+    setLastUpdatedVersion(APP_VERSION);
     await initializeCoreDb({ isRefresh });
 
     return true;
@@ -330,10 +331,6 @@ export function attachIpcListeners() {
       return queryTopFriendsSimple(db, filters);
     }
   );
-
-  ipcMain.handle('set-last-updated-version', async (event, version: string) => {
-    setLastUpdatedVersion(version);
-  });
 
   ipcMain.handle(
     'query-group-chat-by-friends',


### PR DESCRIPTION
It seems that if only half the tables succeed, then the lastUpdatedVersion is never set, so the dashboard loads but it's in an infinite loop where it's asking you to refresh

The real solution is figuring why only have the tables succeed or to but the update at the end, but I think it's the awaits that are messing it up. i think this is fine for now.
