### PR TITLE
🐛: fix check permissions hanging for some users by unpromisifying it

### DIFF
--- a/app/src/components/Home/GetStarted.tsx
+++ b/app/src/components/Home/GetStarted.tsx
@@ -1,10 +1,12 @@
 import { ArrowForwardIcon, Icon } from '@chakra-ui/icons';
 import { Button, Text } from '@chakra-ui/react';
 import { ipcRenderer } from 'electron';
+import * as fs from 'fs';
 import { useState } from 'react';
 import { IconType } from 'react-icons';
 import { FiBarChart2, FiGlobe, FiLock, FiShield } from 'react-icons/fi';
 
+import { chatPaths } from '../../analysis/directories';
 import { logEvent } from '../../utils/analytics';
 
 function BulletPoint({
@@ -49,12 +51,22 @@ export function GetStarted({ onNext }: { onNext: (arg0: boolean) => void }) {
 
   const onStart = async () => {
     setIsLoading(true);
-    const hasAccess = await ipcRenderer.invoke('check-permissions');
+    console.log('about to check access');
+    let hasAccess = false;
+    try {
+      console.log('inside try');
+      fs.accessSync(chatPaths.original, fs.constants.R_OK);
+      console.log('checking 2nd access sync');
+      fs.accessSync(`${process.env.HOME}`, fs.constants.W_OK);
+      console.log('passed permissions check');
+      hasAccess = true;
+    } catch (e: unknown) {
+      console.log(`Failed permissions check: ${e}`);
+      hasAccess = false;
+    }
+
     logEvent({
       eventName: 'GET_STARTED',
-      properties: {
-        hasAccess,
-      },
     });
     onNext(hasAccess);
     setIsLoading(false);

--- a/app/src/main/ipcListeners.ts
+++ b/app/src/main/ipcListeners.ts
@@ -258,24 +258,6 @@ export function attachIpcListeners() {
     return queryRespondReminders(db);
   });
 
-  ipcMain.handle('check-permissions', async () => {
-    return new Promise<boolean>((resolve) => {
-      setTimeout(() => {
-        try {
-          fs.accessSync(chatPaths.original, fs.constants.R_OK);
-          fs.accessSync(`${process.env.HOME}`, fs.constants.W_OK);
-          log.info('Passed permissions check');
-          resolve(true);
-        } catch (e: unknown) {
-          log.info(`Failed permissions check: ${e}`);
-          resolve(false);
-        }
-
-        // NOTE(teddy): Artificially take 1s to give impression of loading
-      }, 1000);
-    });
-  });
-
   ipcMain.handle(
     'get-logs',
     async (event, email: string, reason: string, content: string) => {


### PR DESCRIPTION
It seems for 35% of users, get started would hang. At first, I thought this was an initialize problem, but Amplitude (and all the support tickets) suggests that actually initialize never starts and the permission check just hangs. Hangs meaning it never resolves.

I actually was able to repro locally by removing full disk for my terminal, and then adding it and restarting the app. It hanged. When I logged, it seemed that the promise never resolved. it just waited and waited. not sure what caused that. But i think we can just un-promisify it and just call it at the render level. I can no longer repro.